### PR TITLE
ensured that ionisation_parameter_model is not a log quantity

### DIFF
--- a/create_grids/cloudy/create_cloudy_input_grid.py
+++ b/create_grids/cloudy/create_cloudy_input_grid.py
@@ -256,12 +256,12 @@ if __name__ == "__main__":
             # for spherical geometry the effective log10U is this
             if params_['geometry'] == 'spherical':
 
-                log10U = params_['reference_ionisation_parameter'] + (1/3) * delta_log10Q
+                log10U = np.log10(params_['reference_ionisation_parameter']) + (1/3) * delta_log10Q 
 
             # for plane-parallel geometry the effective just scales with log10Q
             elif params_['geometry'] == 'planeparallel':
 
-                log10U = params_['reference_ionisation_parameter'] + delta_log10Q
+                log10U = np.log10(params_['reference_ionisation_parameter']) + delta_log10Q 
 
             else:
 
@@ -270,14 +270,14 @@ if __name__ == "__main__":
         # if fixed U model is used
         elif params_['ionisation_parameter_model'] == 'fixed':
 
-            log10U = params_['ionisation_parameter']
+            log10U = np.log10(params_['ionisation_parameter']) 
 
         else:
 
             print(f"ERROR: do not understand U model choice: {params_['ionisation_parameter_model']}")
 
         # set log10U to provide cloudy
-        params_['ionisation_parameter'] = float(log10U)
+        params_['ionisation_parameter'] = 10**float(log10U)
 
         # get wavelength
         lam = incident_grid.lam # AA

--- a/create_grids/cloudy/params/c23.01-sps.yaml
+++ b/create_grids/cloudy/params/c23.01-sps.yaml
@@ -1,7 +1,7 @@
 CMB: false  # include CMB heating
 T_floor: 100  # lower gas temperature floor
 ionisation_parameter_model: ref  # which ionisation parameter model to use. `ref` assumes a varying ionisation parameter at a fixed reference age and metallicity
-reference_ionisation_parameter: -2  # value of ionisation parameter at reference value, for U_model='ref'
+reference_ionisation_parameter: 1.0e-2  # value of ionisation parameter at reference value, for U_model='ref'
 reference_log10age: 6.0  # log10(age/year) at which to set reference ionisation parameter, for U_model='ref'
 reference_metallicity: 0.01  # metallicity at which to set reference ionisation parameter, for U_model='ref'
 alpha: 0.0  # alpha element enhancement


### PR DESCRIPTION
## Issue Type
<!-- delete options below as required -->
- Bug
- Enhancement

By making sure reference_ionisation_parameter: 1.0e-2 in the yaml file and 
placing appropriate logs within create_cloudy_input_grids, this avoids nan values
when running cloudy.

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
