### PR TITLE
Update c17.03-sps.yaml

### DIFF
--- a/create_grids/cloudy/params/c17.03-sps.yaml
+++ b/create_grids/cloudy/params/c17.03-sps.yaml
@@ -10,7 +10,7 @@ carbon_abundance: Dopita2006 # scaling for Carbon, either float relative to Sola
 cloudy_version: c17.03
 cosmic_rays: true  # flag for inclusion of cosmic ray heating
 # covering_factor: 1.0  #
-dust_to_metal_ratio: 0.0  # dust to metals ratio in the cloud
+dust_to_metal_ratio: 0.3  # dust to metals ratio in the cloud
 hydrogen_density: 1.0e+2
 radius: 0.01  # log of the radius of the cloud, in parsecs
 stop_T: 500  # stopping temperature


### PR DESCRIPTION
dust_to_metal_ratio should not be zero here, it should be whatever we decide is the default for processing stellar grids, probably 0.3.

## Issue Type
<!-- delete options below as required -->
- Bug
- Document
- Enhancement

## Checklist
- [] I have read the [CONTRIBUTING.md]()
- [] I have added docstrings to all methods
- [] I have added sufficient comments to all lines
- [] I have made corresponding changes to the documentation
- [] My changes generate no pep8 errors
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
