### PR TITLE
Fixed treating all arrays as unyt_array

### DIFF
--- a/create_grids/grid_io.py
+++ b/create_grids/grid_io.py
@@ -356,7 +356,9 @@ class GridFile:
 
             self.write_dataset(
                 "axes/" + axis_key,
-                axis_arr.value,
+                axis_arr.value
+                if isinstance(axis_arr, unyt_array)
+                else axis_arr,
                 descriptions[axis_key],
                 units=units,
             )
@@ -369,7 +371,9 @@ class GridFile:
         # Write out the wavelength array
         self.write_dataset(
             "spectra/wavelength",
-            wavelength.value,
+            wavelength.value
+            if isinstance(wavelength, unyt_array)
+            else wavelength,
             "Wavelength of the spectra grid",
             units=str(wavelength.units),
         )


### PR DESCRIPTION
Introduced a ternary to fix issue where all arrays to write were treated as if they were `unyt_array`s.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
