### PR TITLE
`GridFile` now fully cleaned up and implemented.

### DIFF
--- a/create_grids/grid_io.py
+++ b/create_grids/grid_io.py
@@ -71,7 +71,7 @@ class GridFile:
         # Tell the user if the mode and overwrite don't make sense
         if self.overwrite and (self.mode != "r+" or self.mode != "a"):
             print(
-                "Overwriting is only possible in append mode ('r+'/"a")."
+                "Overwriting is only possible in append mode ('r+'/'a')."
                 f"Mode was: {self.mode}, The overwrite flag will be ignored."
             )
 


### PR DESCRIPTION
The `GridFile` had some niggles left over from being only a draft when merged. It now works and has been tested on a Maraston grid. 

- Opening and closing is now handled more gracefully.
- The links to alternative keys now carry `"Description"` and `"Units"` attributes.
- The specific ionising production rate is now correctly implemented, previously it overwrote itself for each index.
- File creation is now handled properly and errors if the mode is not "w" and the file does not exist. If the mode is "w" and the file is written the mode is switched to "r+" for subsequent openings. This is because the file is now opened and closed in every interaction. Previously the file was open for as long as the object existed but this could lead to clashes.

## Issue Type
<!-- delete options below as required -->
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
