### PR TITLE
Fixed abundances to be up to date with synthesizer

### DIFF
--- a/create_grids/cloudy/create_cloudy_input_grid.py
+++ b/create_grids/cloudy/create_cloudy_input_grid.py
@@ -11,7 +11,11 @@ import yaml
 import h5py
 
 # synthesiser modules
-from synthesizer.abundances import Abundances
+from synthesizer.abundances import (
+    Abundances,
+    depletion_models,
+    solar_abundance_patterns,
+)
 from synthesizer.grid import Grid
 from synthesizer.photoionisation import cloudy17 as cloudy
 
@@ -264,10 +268,12 @@ if __name__ == "__main__":
         # create abundances object
         abundances = Abundances(
             metallicity=float(params_["metallicity"]),
-            dust_to_metal_ratio=params_["dust_to_metal_ratio"],
             alpha=params_["alpha"],
-            nitrogen_abundance=params_["nitrogen_abundance"],
-            carbon_abundance=params_["carbon_abundance"],
+            abundances={
+                "N": params_["nitrogen_abundance"],
+                "C": params_["carbon_abundance"],
+            },
+            depletion_model=depletion_models.Gutkin2016,
         )
         # if reference U model is used
         if params_["ionisation_parameter_model"] == "ref":


### PR DESCRIPTION
The `create_cloudy_input_script` was incompatible with the latest abundance changes. I have modified this script to use the newly defined models from @stephenmwilkins. I am assuming what I have done is correct (i.e. using the default solar abundance, passing the Gutkin2016 depletion model, and passing the param file carbon and nitrogen abundances to `abundances`. (The depletion model should probably be made a parameter in the input file). 

This is a band aid PR which can be review when we move on to "The Big (cloudy) Fix".

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
