### PR TITLE
Provide error when Q(H) = NaN

### DIFF
--- a/src/synthesizer_grids/cloudy/create_cloudy_input_grid.py
+++ b/src/synthesizer_grids/cloudy/create_cloudy_input_grid.py
@@ -315,6 +315,12 @@ if __name__ == "__main__":
         # get a tuple of the incident grid point
         incident_grid_point = tuple(grid_index_[k] for k in incident_grid.axes)
 
+        if np.isnan(incident_grid.log10_specific_ionising_lum["HI"][incident_grid_point]) == True:
+            
+            print(f"""WARNING: there is an issue with the Cloudy input file {i}.in since 
+                  Q(H) = NaN. This occurs at the incident grid point {incident_grid_point} 
+                  and will cause that Cloudy run to fail""")
+
         # join the fixed and current iteration of the grid parameters
         params_ = fixed_params | grid_params_
 

--- a/src/synthesizer_grids/cloudy/create_cloudy_input_grid.py
+++ b/src/synthesizer_grids/cloudy/create_cloudy_input_grid.py
@@ -315,11 +315,13 @@ if __name__ == "__main__":
         # get a tuple of the incident grid point
         incident_grid_point = tuple(grid_index_[k] for k in incident_grid.axes)
 
-        if np.isnan(incident_grid.log10_specific_ionising_lum["HI"][incident_grid_point]) == True:
-            
-            print(f"""WARNING: there is an issue with the Cloudy input file {i}.in since 
-                  Q(H) = NaN. This occurs at the incident grid point {incident_grid_point} 
-                  and will cause that Cloudy run to fail""")
+    if np.isnan(
+        incident_grid.log10_specific_ionising_lum["HI"][incident_grid_point]
+    ):
+        print(f"""WARNING: there is an issue with the Cloudy input file
+                {i}.in since Q(H) = NaN. This occurs at the incident grid
+                point {incident_grid_point} and will cause that Cloudy run
+                to fail""")
 
         # join the fixed and current iteration of the grid parameters
         params_ = fixed_params | grid_params_

--- a/src/synthesizer_grids/cloudy/create_cloudy_input_grid.py
+++ b/src/synthesizer_grids/cloudy/create_cloudy_input_grid.py
@@ -318,10 +318,11 @@ if __name__ == "__main__":
     if np.isnan(
         incident_grid.log10_specific_ionising_lum["HI"][incident_grid_point]
     ):
-        print(f"""WARNING: there is an issue with the Cloudy input file
-                {i}.in since Q(H) = NaN. This occurs at the incident grid
-                point {incident_grid_point} and will cause that Cloudy run
-                to fail""")
+        raise ValueError(
+            f"There is an issue with the Cloudy input file {i}.in since"
+            f"Q(H) = NaN. This occurs at the incident grid point"
+            f"{incident_grid_point} and will cause that Cloudy run to fail."
+        )
 
         # join the fixed and current iteration of the grid parameters
         params_ = fixed_params | grid_params_


### PR DESCRIPTION
I recently came across the situation where `Q(H) = NaN` so I have made a new error alerting the user of `create_cloudy_input_grid` that a Cloudy .in file will fail. I am not an expert in making professional error messages so do give feedback! 

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
