### PR TITLE
Maintaining incident grid metadata through cloudy grid creation

### DIFF
--- a/src/synthesizer_grids/cloudy/utils.py
+++ b/src/synthesizer_grids/cloudy/utils.py
@@ -43,45 +43,67 @@ def get_cloudy_params(param_file="c23.01-sps", param_dir="params"):
     return fixed_params, grid_params
 
 
-def get_grid_properties(axes, axes_values, verbose=True):
+def get_grid_props_cloudy(axes, axes_values, verbose=True):
     """
-    Get the properties of the grid including the dimensions etc.
-    """
+    Get the cloudy related properties of a grid.
 
-    # the grid axes
+    This returns some basic properties needed for processing an incident
+    grid through CLOUDY.
+
+    Args:
+        axes (list)
+            List of axes to vary.
+        axes_values (dict)
+            Dictionary of axis values.
+        verbose (bool)
+            Are we talking or not?
+
+    Returns:
+        n_axes (int)
+            Number of axes.
+        shape (list)
+            Shape of the grid.
+        n_models (int)
+            Number of models.
+        mesh (numpy.ndarray)
+            Mesh of the grid.
+        model_list (numpy.ndarray)
+            List of models.
+        index_list (numpy.ndarray)
+            List of indices of each model within the grid.
+    """
+    # The grid axes
     if verbose:
         print(f"axes: {axes}")
 
-    # number of axes
+    # Number of axes
     n_axes = len(axes)
     if verbose:
         print(f"number of axes: {n_axes}")
 
-    # the shape of the grid (useful for creating outputs)
+    # The shape of the grid (useful for creating outputs)
     shape = list([len(axes_values[axis]) for axis in axes])
     if verbose:
         print(f"shape: {shape}")
 
-    # determine number of models
+    # Determine number of models
     n_models = np.prod(shape)
     if verbose:
         print(f"number of models to run: {n_models}")
 
-    # create the mesh of the grid
+    # Create the mesh of the grid
     mesh = np.array(
         np.meshgrid(*[np.array(axes_values[axis]) for axis in axes])
     )
 
-    # create the list of the models
+    # Create the list of the models
     model_list = mesh.T.reshape(n_models, n_axes)
     if verbose:
         print("model list:")
         print(model_list)
 
-    # create a list of the indices
-
+    # Create a list of the indices
     index_mesh = np.array(np.meshgrid(*[range(n) for n in shape]))
-
     index_list = index_mesh.T.reshape(n_models, n_axes)
     if verbose:
         print("index list:")

--- a/src/synthesizer_grids/grid_io.py
+++ b/src/synthesizer_grids/grid_io.py
@@ -249,7 +249,8 @@ class GridFile:
         # Include a brief description
         dset.attrs["Description"] = description
 
-        # Write out whether we should log this dataset when read
+        # Write out whether we should log this dataset before using it to
+        # interpolate spectra
         dset.attrs["log_on_read"] = log_on_read
 
         # Handle any other attributes passed as kwargs
@@ -354,6 +355,7 @@ class GridFile:
         alt_axes=(),
         descriptions={},
         model={},
+        weight="initial_masses",
     ):
         """
         Write out the common parts of a Synthesizer grid.
@@ -388,6 +390,11 @@ class GridFile:
                 be overidden here.
             model (dict)
                 A dictionary containing the metadata of the model used.
+            weight (str)
+                The variable to used to normalise the spectra in the grid. For
+                instance, in most SPS models this will initial mass normalised,
+                the Synthesizer property for this is "initial_masses". By
+                default this is set to "initial_masses".
 
         Raises:
             ValueError
@@ -444,6 +451,9 @@ class GridFile:
             "Wavelength of the spectra grid",
             log_on_read=False,
         )
+
+        # Store the weight variable as an attribute
+        self.write_attribute("spectra", "WeightVariable", weight)
 
         # Write out each spectra
         for key, val in spectra.items():

--- a/src/synthesizer_grids/incident/sps/install_bpass2.2.1.py
+++ b/src/synthesizer_grids/incident/sps/install_bpass2.2.1.py
@@ -160,7 +160,7 @@ def make_grid(original_model_name, bin, input_dir, grid_dir):
     # A dictionary with Boolean values for each axis, where True
     # indicates that the attribute should be interpolated in
     # logarithmic space.
-    log_on_read = {"ages": True, "metallicities": False}
+    log_on_read = {"ages": True, "metallicities": True}
 
     # Write everything out thats common to all models
     out_grid.write_grid_common(

--- a/src/synthesizer_grids/incident/sps/install_bpass2.3.py
+++ b/src/synthesizer_grids/incident/sps/install_bpass2.3.py
@@ -156,7 +156,7 @@ def make_single_alpha_grid(
     # A dictionary with Boolean values for each axis, where True
     # indicates that the attribute should be interpolated in
     # logarithmic space.
-    log_on_read = {"ages": True, "metallicities": False}
+    log_on_read = {"ages": True, "metallicities": True}
 
     # Write everything out thats common to all models
     out_grid.write_grid_common(


### PR DESCRIPTION
The creation of an empty Synthesizer grid during cloudy grid generation didn't respect the incident grid metadata (an important update introduced by @sophie-newman). This is now fixed. 

This is the first of a set of fixes to ensure the output Synthesizer grids include everything to simplify things on the Synthesizer side.

Requires https://github.com/flaresimulations/synthesizer/pull/811

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
