### PR TITLE
Typo in model metadata method

### DIFF
--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -81,7 +81,7 @@ def create_empty_grid(
     )
 
     # Copy over the model metadata
-    out_grid.write_model_metadata(incident_grid._model_metadata.items())
+    out_grid.write_model_metadata(incident_grid._model_metadata)
 
     # Set a list of the axes including the incident and new grid axes
     axes = list(incident_grid.axes) + list(grid_params.keys())


### PR DESCRIPTION
Removing rogue `.items()`

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
