### PR TITLE
Simplifying cloudy command line args for spectra

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ options:
   --line-calc-method LINE_CALC_METHOD
                         The method used to calculate the line fluxes (either 'lines' or 'linelist')
   --machine MACHINE     The machine used to run the cloudy runs (currently only supports apollo)
-  --norm-by-Q, -Q       Should the grid be normalised by the specific ionising luminosity?
+  --norm-by-Q, -Q       Should the grid be normalised by the specific ionising luminosity? (default is True)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package includes scripts and tools for generating grids for use by the `syn
 
 To use `synthesizer-grids` you'll first need to install it. To do this you can simply invoke the following at the root of the repo.
 
-``` sh
+```sh
 pip install .
 ```
 
@@ -20,12 +20,13 @@ Unfortunately, since SPS codes adopt heterogenous approaches to everything the c
 
 The generation scripts can be found within `src/synthesizer-grids/incident` with sub-directories for each type of model (e.g. `sps` or `blackholes`). These generation scripts all take command line arguments. These commandline arguments can be seen by running the script with the help flag.
 
-``` sh
+```sh
 python <script>.py --help
 ```
+
 Most models only take the standard arguments, but others can include other options. Here is an example `--help` output from the BC03 SPS model containing the default arguments.
 
-``` sh
+```sh
 usage: install_bc03.py [-h] --grid_dir GRID_DIR [--input_dir INPUT_DIR] [--download]
 
 BC03 download and grid creation
@@ -38,7 +39,6 @@ options:
 ```
 
 Note that all scripts will only download the data needed for the model if the download flag is set. This means the data need only be downloaded once for each model.
-
 
 ## Processing grids with CLOUDY
 
@@ -56,36 +56,59 @@ To create an input grid, we run `make_cloudy_input_grid.py`. This takes the foll
 `-m (--machine)`: the type of HPC on which you are running. If not provided, no submission script will be written.
 `-incident_grid`: The name of the synthesizer incident grid on which you wish to run `cloudy`.
 `-cloudy_params`: the YAML file containing `cloudy` parameters for modelling. See the examples for more details. These can be single values or arrays resulting in the creating of higher-dimensionality grids. Also included is the `cloudy` version.
-`-cloudy_path`: the path to the `cloudy` directory. **Note** this is not the path to executable. This was done to allow multiple versions of cloudy to exist simultanously.  
+`-cloudy_path`: the path to the `cloudy` directory. **Note** this is not the path to executable. This was done to allow multiple versions of cloudy to exist simultanously.
 
 #### Using a cloudy shape command
 
 As an alternative we can create a grid directly from using one of `cloudy`'s in-built shape commands (e.g. blackbody). To do this we need to provide a yaml file containing the name of the model (at the moment this is limited to `blackbody` and `agn`) with all the parameters, including any that are to be varied as a list.
 
 #### The param YAML file
+
 This contains the parameters that will be input into CLOUDY.
 
 Users can provide arrays/lists of parameters they wish to iterate over. In this case, the code will create individual runs for each of the parameters specified, with the following naming convention:
 
-{sps_grid}_{imf}_cloudy_{param}_{value}
+{sps*grid}*{imf}_cloudy_{param}\_{value}
 
 where {param} is the key in the param file of the parameter to be varied, and {value} is the value to be provided. If this is numeric, it will be converted to a string, and if it is negative, the '-' will be substituted for 'm'.
-
 
 ### Creating cloudy synthesizer grids
 
 Next we need to combine the cloudy ouputs to create a new `synthesizer` grid. To do this we run `create_synthesizer_grid.py`. This takes the following arguments:
 
-`-synthesizer_data_dir`: The directory containing both the cloudy runs (`cloudy/`) and grids (`grids/`).
-`-grid_name`: The full grid name.
-`-include_spectra`: Whether to include spectra or just include line properties. Depending on the science context for large grids it might be sensible to not save the full spectra.
-`-replace`: Some models continuously fail. This is a last resort options to instead use the nearest model. **I RECOMMEND NEVER SETTING THIS TO TRUE**.
-`-line_calc_method`: Change the way line quantities are calculated.
+```bash
+usage: create_synthesizer_grid.py [-h] --grid-dir GRID_DIR [--verbose] --cloudy-dir CLOUDY_DIR --incident-grid INCIDENT_GRID [--cloudy-grid CLOUDY_GRID] [--cloudy-params CLOUDY_PARAMS]
+                                  [--cloudy-params-addition CLOUDY_PARAMS_ADDITION] [--include-spectra INCLUDE_SPECTRA] [--replace REPLACE] [--line-calc-method LINE_CALC_METHOD] [--machine MACHINE] [--norm-by-Q]
 
+Create Synthesizer HDF5 grid files from cloudy outputs.
+
+options:
+  -h, --help            show this help message and exit
+  --grid-dir GRID_DIR   The directory containing (or to contain) the grids.
+  --verbose             Are we talking?
+  --cloudy-dir CLOUDY_DIR
+                        The directory containing each of the individual cloudy run outputs.
+  --incident-grid INCIDENT_GRID
+                        The name of the incident grid (the grid used to generate the cloudy runs).
+  --cloudy-grid CLOUDY_GRID
+                        The name of the new cloudy reprocessed grid (default to <incident_grid>_cloudy.hdf5).
+  --cloudy-params CLOUDY_PARAMS
+                        The path to the cloudy parameter file.
+  --cloudy-params-addition CLOUDY_PARAMS_ADDITION
+                        The path to the cloudy 'extra' parameter file.
+  --include-spectra INCLUDE_SPECTRA
+                        Should the spectra be included in the grid?
+  --replace             Should missing files be replaced?
+  --line-calc-method LINE_CALC_METHOD
+                        The method used to calculate the line fluxes (either 'lines' or 'linelist')
+  --machine MACHINE     The machine used to run the cloudy runs (currently only supports apollo)
+  --norm-by-Q, -Q       Should the grid be normalised by the specific ionising luminosity?
+
+```
 
 ### Scripts
 
-The cloudy directory also includes a script folder `apollo_production_scripts/` for processing multiple grids automatically. Essentially there are two scripts, one for creating the cloudy inputs and a second for creating the ultimate synthesizer grids. These loop over the contents of `incident.txt` and `grids.txt` to get the input parameters. 
+The cloudy directory also includes a script folder `apollo_production_scripts/` for processing multiple grids automatically. Essentially there are two scripts, one for creating the cloudy inputs and a second for creating the ultimate synthesizer grids. These loop over the contents of `incident.txt` and `grids.txt` to get the input parameters.
 
 These scripts will only work on Sussex's Apollo HPC system. Thus, if you want to use something similar please copy and adapt them as required. If you want them to form part of the package please make a new folder.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Next we need to combine the cloudy ouputs to create a new `synthesizer` grid. To
 
 ```bash
 usage: create_synthesizer_grid.py [-h] --grid-dir GRID_DIR [--verbose] --cloudy-dir CLOUDY_DIR --incident-grid INCIDENT_GRID [--cloudy-grid CLOUDY_GRID] [--cloudy-params CLOUDY_PARAMS]
-                                  [--cloudy-params-addition CLOUDY_PARAMS_ADDITION] [--include-spectra INCLUDE_SPECTRA] [--replace REPLACE] [--line-calc-method LINE_CALC_METHOD] [--machine MACHINE] [--norm-by-Q]
+                                  [--cloudy-params-addition CLOUDY_PARAMS_ADDITION] [--include-spectra] [--replace] [--line-calc-method LINE_CALC_METHOD] [--machine MACHINE] [--norm-by-Q]
 
 Create Synthesizer HDF5 grid files from cloudy outputs.
 
@@ -96,8 +96,7 @@ options:
                         The path to the cloudy parameter file.
   --cloudy-params-addition CLOUDY_PARAMS_ADDITION
                         The path to the cloudy 'extra' parameter file.
-  --include-spectra INCLUDE_SPECTRA
-                        Should the spectra be included in the grid?
+  --include-spectra     Should the spectra be included in the grid?
   --replace             Should missing files be replaced?
   --line-calc-method LINE_CALC_METHOD
                         The method used to calculate the line fluxes (either 'lines' or 'linelist')

--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -109,10 +109,8 @@ def create_empty_grid(
     # Compute the amount we may have to expand the axes (if we don't need to
     # expand this is harmless)
     expansion = int(
-        np.product(shape)
-        / np.product(
-            incident_grid.log10_specific_ionising_luminosity["HI"].shape
-        )
+        np.prod(shape)
+        / np.prod(incident_grid.log10_specific_ionising_luminosity["HI"].shape)
     )
 
     # Loop over ions
@@ -245,7 +243,7 @@ def load_grid_params(param_file="c23.01-sps", param_dir="params"):
             dictionary of parameters that vary on the grid
     """
     # Open parameter file
-    with open(f"{param_dir}/{param_file}.yaml", "r") as stream:
+    with open(f"{param_file}.yaml", "r") as stream:
         try:
             params = yaml.safe_load(stream)
         except yaml.YAMLError as exc:
@@ -625,6 +623,12 @@ def add_lines(
                     infile, extension="emergent_elin"
                 )
 
+            else:
+                raise ValueError(
+                    f"Unrecognised line type: {line_type} "
+                    "(must be 'lines' or 'linelist')"
+                )
+
             for id_, wavelength_, luminosity_ in zip(
                 id, wavelength, luminosity
             ):
@@ -666,56 +670,9 @@ def add_lines(
 if __name__ == "__main__":
     # Set up the command line arguments
     parser = Parser(
-        description="Create Synthesizer HDF5 grid files from cloudy outputs."
+        description="Create Synthesizer HDF5 grid files from cloudy outputs.",
+        cloudy_args=True,
     )
-
-    # Path to directory where cloudy runs are
-    parser.add_argument("--cloudy_dir", type=str, required=True)
-
-    # The name of the incident grid
-    parser.add_argument("--incident_grid", type=str, required=True)
-
-    # The cloudy parameters, including any grid axes
-    parser.add_argument(
-        "--cloudy_params", type=str, required=False, default="c17.03-sps"
-    )
-
-    # A second cloudy parameter set which supersedes the above
-    parser.add_argument(
-        "--cloudy_params_addition",
-        type=str,
-        required=False,
-    )
-
-    # Include spectra
-    parser.add_argument(
-        "--include_spectra",
-        type=bool,
-        default=True,
-        required=False,
-    )
-
-    # Boolean flag as to whether to attempt to replace missing files
-    parser.add_argument("--replace", type=bool, default=False, required=False)
-
-    # Define the line calculation method.
-    parser.add_argument(
-        "--line_calc_method",
-        type=str,
-        default="lines",
-        required=False,
-    )
-
-    # Define the line calculation method.
-    parser.add_argument(
-        "--machine",
-        type=str,
-        default=None,
-        required=False,
-    )
-
-    # verbosity flag
-    parser.add_argument("--verbose", type=bool, required=False, default=True)
 
     args = parser.parse_args()
 

--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -65,13 +65,13 @@ def create_empty_grid(
     """
     # Open the parent incident grid
     incident_grid = Grid(
-        incident_grid_name + ".hdf5",
+        incident_grid_name,
         grid_dir=grid_dir,
         read_lines=False,
     )
 
     # Make the new grid
-    out_grid = GridFile(f"{grid_dir}/{new_grid_name}.hdf5")
+    out_grid = GridFile(f"{grid_dir}/{new_grid_name}")
 
     # Add attribute with the original incident grid axes
     out_grid.write_attribute(
@@ -110,17 +110,17 @@ def create_empty_grid(
     # expand this is harmless)
     expansion = int(
         np.prod(shape)
-        / np.prod(incident_grid.log10_specific_ionising_luminosity["HI"].shape)
+        / np.prod(incident_grid.log10_specific_ionising_lum["HI"].shape)
     )
 
     # Loop over ions
-    for ion in incident_grid.log10_specific_ionising_luminosity.keys():
+    for ion in incident_grid.log10_specific_ionising_lum.keys():
         # If there are no additional axes simply copy over the incident
-        # log10_specific_ionising_luminosity .
+        # .log10_specific_ionising_lum .
         if len(axes) == len(incident_grid.axes):
             out_grid.write_dataset(
                 key=f"log10_specific_ionising_luminosity/{ion}",
-                data=incident_grid.log10_specific_ionising_luminosity[ion]
+                data=incident_grid.log10_specific_ionising_lum[ion]
                 * dimensionless,
                 description="The specific ionising photon luminosity for"
                 f" {ion}",
@@ -132,8 +132,7 @@ def create_empty_grid(
         else:
             # Create new array with repeated elements
             log10_specific_ionising_luminosity = np.repeat(
-                incident_grid.log10_specific_ionising_luminosity[ion]
-                * dimensionless,
+                incident_grid.log10_specific_ionising_lum[ion] * dimensionless,
                 expansion,
                 axis=-1,
             )
@@ -149,11 +148,14 @@ def create_empty_grid(
     # Add attribute with the full grid axes
     out_grid.write_attribute(group="/", attr_key="axes", data=axes)
 
-    # copy over the weight attribute from the incident grid
+    # Copy over the weight attribute from the incident grid
+    weight_var = getattr(incident_grid, "_weight_var", None)
+    if weight_var is None:
+        weight_var = "None"
     out_grid.write_attribute(
         group="/",
         attr_key="weightvariable",
-        data=incident_grid._weight_var,
+        data=weight_var,
     )
 
     # Now write out the grid axes, we first do the incident grid axes so we
@@ -204,24 +206,13 @@ def create_empty_grid(
                 f"create_synthesizer_grid.py"
             )
 
-    # Add other parameters as attributes
-    for k, v in params.items():
-        # If v is None then convert to string None for saving in the
-        # HDF5 file.
-        if v is None:
-            v = "None"
-
-        # If the parameter is a dictionary (e.g. as used for abundances)
-        if isinstance(v, dict):
-            for k2, v2 in v.items():
-                out_grid.write_attribute(group="k", attr_key=k2, data=v2)
-        else:
-            out_grid.write_attribute(group="/", attr_key=k, data=v)
+    # Write out cloudy parameters
+    out_grid.write_cloudy_metadata(params)
 
     return out_grid, incident_grid
 
 
-def load_grid_params(param_file="c23.01-sps", param_dir="params"):
+def load_grid_params(param_file="c23.01-sps"):
     """
     Read parameters from a yaml parameter file.
 
@@ -232,9 +223,7 @@ def load_grid_params(param_file="c23.01-sps", param_dir="params"):
 
     Arguments:
         param_file (str)
-            filename of the parameter file
-        param_dir (str)
-            directory containing the parameter file
+            Path to the the parameter file
 
     Returns:
         fixed_params (dict)
@@ -243,7 +232,7 @@ def load_grid_params(param_file="c23.01-sps", param_dir="params"):
             dictionary of parameters that vary on the grid
     """
     # Open parameter file
-    with open(f"{param_file}.yaml", "r") as stream:
+    with open(param_file, "r") as stream:
         try:
             params = yaml.safe_load(stream)
         except yaml.YAMLError as exc:
@@ -302,8 +291,6 @@ def get_grid_properties_hf(hf, verbose=True):
 
 def check_cloudy_runs(
     out_grid,
-    grid_name,
-    grid_dir,
     cloudy_dir,
     replace=False,
     files_to_check=["cont"],
@@ -314,10 +301,6 @@ def check_cloudy_runs(
     Args:
         out_grid (GridFile)
             The grid file to check.
-        grid_name (str)
-            Name of the grid
-        grid_dir (str)
-            Parent directory for the grids.
         cloudy_dir (str)
             Parent directory for the cloudy runs.
         replace (boolean)
@@ -335,7 +318,6 @@ def check_cloudy_runs(
         axis: out_grid.read_dataset(f"axes/{axis}") for axis in axes
     }
     (
-        axes,
         n_axes,
         shape,
         n_models,
@@ -347,7 +329,7 @@ def check_cloudy_runs(
     # List of failed models
     failed_list = []
     for i, grid_params_ in enumerate(model_list):
-        infile = f"{cloudy_dir}/{grid_name}/{i+1}"
+        infile = f"{cloudy_dir}/{i+1}"
         failed = False
 
         # Check if files exist
@@ -374,7 +356,7 @@ def check_cloudy_runs(
             if replace:
                 for ext in files_to_check:
                     shutil.copyfile(
-                        f"{cloudy_dir}/{grid_name}/{i}.{ext}",
+                        f"{cloudy_dir}/{i}.{ext}",
                         infile + f".{ext}",
                     )
 
@@ -422,7 +404,6 @@ def add_spectra(
         axis: out_grid.read_dataset(f"axes/{axis}") for axis in axes
     }
     (
-        axes,
         n_axes,
         shape,
         n_models,
@@ -432,7 +413,10 @@ def add_spectra(
     ) = get_grid_props_cloudy(axes, axes_values, verbose=True)
 
     # Determine the cloudy version...
-    cloudy_version = out_grid.read_attribute("cloudy_version")
+    cloudy_version = out_grid.read_attribute(
+        "cloudy_version",
+        group="CloudyParams",
+    )
 
     # ... and use to select the correct module.
     if cloudy_version.split(".")[0] == "c23":
@@ -442,7 +426,7 @@ def add_spectra(
 
     # Read first spectra from the first grid point to get length and
     # wavelength grid.
-    lam = cloudy.read_wavelength(f"{cloudy_dir}/{grid_name}/1")
+    lam = cloudy.read_wavelength(f"{cloudy_dir}/1")
 
     # Write the spectra names... for some reason (not sure why since .keys()
     # gives the same result)
@@ -467,7 +451,7 @@ def add_spectra(
         indices = tuple(indices)
 
         # Define the infile (cloudy output file)
-        infile = f"{cloudy_dir}/{grid_name}/{i+1}"
+        infile = f"{cloudy_dir}/{i+1}"
 
         # Read the continuum file containing the spectra
         spec_dict = cloudy.read_continuum(infile, return_dict=True)
@@ -503,11 +487,18 @@ def add_spectra(
                 spec_dict[spec_name] * spectra["normalisation"][indices]
             )
 
+    # Apply units to the spectra
+    for spec in spectra:
+        spectra[spec] *= erg / s / Hz
+
     # Write the spectra out
+    weight_var = getattr(incident_grid, "_weight_var", None)
+    if weight_var is None:
+        weight_var = "None"
     out_grid.write_spectra(
         spectra,
-        wavelengths=lam,
-        weight=incident_grid._weight_var,  # this is written already
+        wavelength=lam * Angstrom,
+        weight=weight_var,  # this is written already but harmless
     )
 
     return spectra
@@ -539,7 +530,7 @@ def add_lines(
     """
 
     # open the new grid
-    with h5py.File(f"{grid_dir}/{grid_name}.hdf5", "a") as hf:
+    with h5py.File(f"{grid_dir}/{grid_name}", "a") as hf:
         # Get the properties of the grid including the dimensions etc.
         (
             axes,
@@ -552,7 +543,10 @@ def add_lines(
         ) = get_grid_properties_hf(hf)
 
         # Determine the cloudy version...
-        cloudy_version = hf.attrs["cloudy_version"]
+        cloudy_version = out_grid.read_attribute(
+            "cloudy_version",
+            group="CloudyParams",
+        )
 
         # ... and use to select the correct module.
         if cloudy_version.split(".")[0] == "c23":
@@ -574,7 +568,7 @@ def add_lines(
         lines = hf.create_group("lines")
 
         if line_type == "linelist":
-            infile = f"{cloudy_dir}/{grid_name}/1"
+            infile = f"{cloudy_dir}/1"
             lines_to_include, _, _ = cloudy.read_linelist(
                 infile, extension="emergent_elin"
             )
@@ -591,7 +585,7 @@ def add_lines(
             indices = tuple(indices)
 
             # define the infile
-            infile = f"{cloudy_dir}/{grid_name}/{i+1}"
+            infile = f"{cloudy_dir}/{i+1}"
 
             # get TOTAL continuum spectra
             if include_spectra:
@@ -673,19 +667,42 @@ if __name__ == "__main__":
         description="Create Synthesizer HDF5 grid files from cloudy outputs.",
         cloudy_args=True,
     )
-
     args = parser.parse_args()
 
     # Unpack arguments
     grid_dir = args.grid_dir
     cloudy_dir = args.cloudy_dir
+    incident_grid_name = args.incident_grid
+    new_grid_name = (
+        args.cloudy_grid
+        if args.cloudy_grid is not None
+        else incident_grid_name
+    )
+    cloudy_paramfile = args.cloudy_params
+    extra_cloudy_paramfile = args.cloudy_params_addition
+    include_spectra = args.include_spectra
+    replace_failed = args.replace
+    line_type = args.line_calc_method
+    machine = args.machine
     verbose = args.verbose
 
-    # Construct grid_name from incident grid and parameter file
-    grid_name = f"{args.incident_grid}_cloudy-{args.cloudy_params}"
-    incident_grid_name = args.incident_grid
+    # Check for extensions
+    if cloudy_paramfile.split(".")[-1] != "yaml":
+        cloudy_paramfile += ".yaml"
+    if extra_cloudy_paramfile is not None:
+        if extra_cloudy_paramfile.split(".")[-1] != "yaml":
+            extra_cloudy_paramfile += ".yaml"
+    if incident_grid_name.split(".")[-1] != "hdf5":
+        incident_grid_name += ".hdf5"
+    if new_grid_name.split(".")[-1] != "hdf5":
+        new_grid_name += ".hdf5"
 
-    include_spectra = args.include_spectra
+    # Define the grid name (the user has either set this or its the same as
+    # the incident grid name with a cloudy suffix)
+    if new_grid_name is None:
+        new_grid_name = incident_grid_name
+    if "cloudy" not in new_grid_name:
+        new_grid_name = f"{new_grid_name.replace('.hdf5', '')}_cloudy.hdf5"
 
     # Load the cloudy parameters you are going to run
     fixed_params, grid_params = load_grid_params(args.cloudy_params)
@@ -693,9 +710,6 @@ if __name__ == "__main__":
     # If an additional parameter set is provided supersede the default
     # parameters with these and adjust the new grid name.
     if args.cloudy_params_addition:
-        grid_name = (
-            grid_name + f"-{args.cloudy_params_addition.split('/')[-1]}"
-        )
         additional_fixed_params, additional_grid_params = load_grid_params(
             args.cloudy_params_addition
         )
@@ -704,12 +718,14 @@ if __name__ == "__main__":
 
     params = fixed_params | grid_params
 
+    print(params)
+
     # Create empty synthesizer grid, this returns a GridFile object we can
     # add spectra and lines to below
     out_grid, incident_grid = create_empty_grid(
         grid_dir,
         incident_grid_name,
-        grid_name,
+        new_grid_name,
         params,
         grid_params,
     )
@@ -718,8 +734,6 @@ if __name__ == "__main__":
     # if they fail.
     failed_list = check_cloudy_runs(
         out_grid,
-        grid_name,
-        grid_dir,
         cloudy_dir,
         replace=args.replace,
     )
@@ -739,7 +753,7 @@ if __name__ == "__main__":
 
             # replace input_names with list of failed runs
             with open(
-                f"{cloudy_dir}/{grid_name}/input_names.txt", "w"
+                f"{cloudy_dir}/{incident_grid_name}/input_names.txt", "w"
             ) as myfile:
                 myfile.write("\n".join(map(str, failed_list)))
 
@@ -750,7 +764,7 @@ if __name__ == "__main__":
             add_spectra(
                 out_grid,
                 incident_grid,
-                grid_name,
+                new_grid_name,
                 cloudy_dir,
                 spec_names=("incident", "transmitted", "nebular", "linecont"),
                 weight="initial_masses",
@@ -759,7 +773,7 @@ if __name__ == "__main__":
 
         # add lines
         add_lines(
-            grid_name,
+            new_grid_name,
             grid_dir,
             cloudy_dir,
             line_type="linelist",

--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -5,8 +5,10 @@ synthesizer grid is a HDF5 file that contains the spectra and line luminosities
 from cloudy outputs.
 
 Example usage:
-    python create_synthesizer_grid.py --cloudy_dir=cloudy_dir
-    --incident_grid=incident_grid --cloudy_params=cloudy_params
+    python create_synthesizer_grid.py --grid-dir /path/to/grid
+        --cloudy-dir /path/to/cloudy --incident-grid incident_grid.hdf5
+        --cloudy-params c17.03-sps --include-spectra True --replace
+        --line-calc-method linelist
 """
 
 import os

--- a/src/synthesizer_grids/grid_io.py
+++ b/src/synthesizer_grids/grid_io.py
@@ -587,6 +587,44 @@ class GridFile:
 
         self._close_file()
 
+    def write_cloudy_metadata(self, params):
+        """
+        Write out the Cloudy metadata.
+
+        Args:
+            params (dict)
+                A dictionary containing the metadata of the Cloudy run.
+        """
+        # Open the file
+        self._open_file()
+
+        # Create the CloudyParams group if it doesn't exist
+        if "CloudyParams" not in self.hdf:
+            self.hdf.create_group("CloudyParams")
+        cloudy_grp = self.hdf["CloudyParams"]
+
+        # Add other parameters as attributes
+        for k, v in params.items():
+            # If v is None then convert to string None for saving in the
+            # HDF5 file.
+            if v is None:
+                v = "None"
+
+            # If the parameter is a dictionary (e.g. as used for abundances)
+            if isinstance(v, dict):
+                print(k, v)
+                # Create group for this key
+                nested_grp = cloudy_grp.create_group(k)
+
+                for k2, v2 in v.items():
+                    nested_grp.attrs[k2] = v2
+
+            else:
+                cloudy_grp.attrs[k] = v
+
+        # Close the file
+        self._close_file()
+
     def get_grid_properties(self, verbose=False):
         """Get the properties of the grid including the dimensions etc."""
         self._open_file()

--- a/src/synthesizer_grids/parser.py
+++ b/src/synthesizer_grids/parser.py
@@ -23,7 +23,7 @@ class Parser(argparse.ArgumentParser):
             The parser instance.
     """
 
-    def __init__(self, description, with_alpha=False):
+    def __init__(self, description, with_alpha=False, cloudy_args=False):
         """
         Create the parser instance.
 
@@ -36,34 +36,137 @@ class Parser(argparse.ArgumentParser):
         # Create the parser
         super(Parser, self).__init__(description=description)
 
+        # First add the common arguments
+
         # Add filepath argument for the grids.
         self.add_argument(
-            "--grid_dir",
+            "--grid-dir",
             type=str,
             help="The grid file path",
             required=True,
         )
 
-        # Add filepath argument for the input files used to create SPS incident
-        # grids.
+        # Are we talking?
         self.add_argument(
-            "--input_dir",
-            type=str,
-            help="The input file path",
+            "--verbose",
+            type=bool,
             required=False,
+            default=True,
+            description="Are we talking?",
         )
 
-        # Add download flag
-        self.add_argument(
-            "--download",
-            "-d",
-            action="store_true",
-            help="Should the data be downloaded?",
-        )
+        # Now add the cloudy specific arguments or incident grid arguments
+        if not cloudy_args:
+            self._add_incident_args()
+        else:
+            self._add_cloudy_args()
 
         # Add alpha flag if necessary
         if with_alpha:
             self._add_alpha_args()
+
+        def _add_incident_args(self):
+            """Add arguments for incident grids."""
+            # Add filepath argument for the input files used to create
+            # SPS incident grids.
+            self.add_argument(
+                "--input-dir",
+                type=str,
+                help="The input file path",
+                required=False,
+            )
+
+            # Add download flag
+            self.add_argument(
+                "--download",
+                "-d",
+                action="store_true",
+                help="Should the data be downloaded?",
+            )
+
+        def _add_cloudy_args(self):
+            """Add arguments for cloudy grids."""
+            # Path to directory where cloudy runs are
+            self.add_argument(
+                "--cloudy-dir",
+                type=str,
+                required=True,
+                description="The directory containing each "
+                "of the individual cloudy run outputs.",
+            )
+
+            # The name of the incident grid
+            self.add_argument(
+                "--incident-grid",
+                type=str,
+                required=True,
+                description="The name of the incident grid (the grid "
+                "used to generate the cloudy runs).",
+            )
+
+            # The name for the new cloudy reprocessed grid (by default this
+            # is the same as the incident grid with a '_cloudy' suffix)
+            self.add_argument(
+                "--cloudy-grid",
+                type=str,
+                required=False,
+                description="The name of the new cloudy reprocessed grid.",
+            )
+
+            # The cloudy parameters, including any grid axes
+            self.add_argument(
+                "--cloudy-params",
+                type=str,
+                required=False,
+                default="c17.03-sps",
+                description="The path to the cloudy parameter file.",
+            )
+
+            # A second cloudy parameter set which supersedes the above
+            self.add_argument(
+                "--cloudy_params_addition",
+                type=str,
+                required=False,
+                description="The path to the cloudy 'extra' parameter file.",
+            )
+
+            # Should we include the spectra in the grid?
+            self.add_argument(
+                "--include_spectra",
+                type=bool,
+                default=True,
+                required=False,
+                description="Should the spectra be included in the grid?",
+            )
+
+            # Boolean flag as to whether to attempt to replace missing files
+            self.add_argument(
+                "--replace",
+                type=bool,
+                default=False,
+                required=False,
+                description="Should missing files be replaced?",
+            )
+
+            # Define the line calculation method.
+            self.add_argument(
+                "--line_calc_method",
+                type=str,
+                default="lines",
+                required=False,
+                description="The method used to calculate the line fluxes "
+                "(either 'lines' or 'linelist')",
+            )
+
+            # Define the machine (for rerunning cloudy runs)
+            self.add_argument(
+                "--machine",
+                type=str,
+                default=None,
+                required=False,
+                description="The machine used to run the cloudy runs "
+                "(currently only supports apollo)",
+            )
 
     def _add_alpha_args(self):
         """Add arguments for alpha enhancement."""

--- a/src/synthesizer_grids/parser.py
+++ b/src/synthesizer_grids/parser.py
@@ -135,8 +135,7 @@ class Parser(argparse.ArgumentParser):
         self.add_argument(
             "--include-spectra",
             type=bool,
-            default=True,
-            required=False,
+            action="store_true",
             help="Should the spectra be included in the grid?",
         )
 

--- a/src/synthesizer_grids/parser.py
+++ b/src/synthesizer_grids/parser.py
@@ -171,10 +171,10 @@ class Parser(argparse.ArgumentParser):
         self.add_argument(
             "--norm-by-Q",
             "-Q",
-            action="store_true",
             default=True,
+            required=False,
             help="Should the grid be normalised by the specific "
-            "ionising luminosity?",
+            "ionising luminosity? (default is True)",
         )
 
     def _add_alpha_args(self):

--- a/src/synthesizer_grids/parser.py
+++ b/src/synthesizer_grids/parser.py
@@ -42,7 +42,7 @@ class Parser(argparse.ArgumentParser):
         self.add_argument(
             "--grid-dir",
             type=str,
-            help="The grid file path",
+            help="The directory containing (or to contain) the grids.",
             required=True,
         )
 
@@ -110,7 +110,8 @@ class Parser(argparse.ArgumentParser):
             type=str,
             required=False,
             default=None,
-            help="The name of the new cloudy reprocessed grid.",
+            help="The name of the new cloudy reprocessed grid (defaults "
+            "to <incident_grid>_cloudy.hdf5).",
         )
 
         # The cloudy parameters, including any grid axes
@@ -142,9 +143,7 @@ class Parser(argparse.ArgumentParser):
         # Boolean flag as to whether to attempt to replace missing files
         self.add_argument(
             "--replace",
-            type=bool,
-            default=False,
-            required=False,
+            action="store_true",
             help="Should missing files be replaced?",
         )
 

--- a/src/synthesizer_grids/parser.py
+++ b/src/synthesizer_grids/parser.py
@@ -49,10 +49,9 @@ class Parser(argparse.ArgumentParser):
         # Are we talking?
         self.add_argument(
             "--verbose",
-            type=bool,
-            required=False,
+            action="store_true",
             default=False,
-            description="Are we talking?",
+            help="Are we talking?",
         )
 
         # Now add the cloudy specific arguments or incident grid arguments
@@ -65,108 +64,119 @@ class Parser(argparse.ArgumentParser):
         if with_alpha:
             self._add_alpha_args()
 
-        def _add_incident_args(self):
-            """Add arguments for incident grids."""
-            # Add filepath argument for the input files used to create
-            # SPS incident grids.
-            self.add_argument(
-                "--input-dir",
-                type=str,
-                help="The input file path",
-                required=False,
-            )
+    def _add_incident_args(self):
+        """Add arguments for incident grids."""
+        # Add filepath argument for the input files used to create
+        # SPS incident grids.
+        self.add_argument(
+            "--input-dir",
+            type=str,
+            help="The input file path",
+            required=False,
+        )
 
-            # Add download flag
-            self.add_argument(
-                "--download",
-                "-d",
-                action="store_true",
-                help="Should the data be downloaded?",
-            )
+        # Add download flag
+        self.add_argument(
+            "--download",
+            "-d",
+            action="store_true",
+            help="Should the data be downloaded?",
+        )
 
-        def _add_cloudy_args(self):
-            """Add arguments for cloudy grids."""
-            # Path to directory where cloudy runs are
-            self.add_argument(
-                "--cloudy-dir",
-                type=str,
-                required=True,
-                description="The directory containing each "
-                "of the individual cloudy run outputs.",
-            )
+    def _add_cloudy_args(self):
+        """Add arguments for cloudy grids."""
+        # Path to directory where cloudy runs are
+        self.add_argument(
+            "--cloudy-dir",
+            type=str,
+            required=True,
+            help="The directory containing each "
+            "of the individual cloudy run outputs.",
+        )
 
-            # The name of the incident grid
-            self.add_argument(
-                "--incident-grid",
-                type=str,
-                required=True,
-                description="The name of the incident grid (the grid "
-                "used to generate the cloudy runs).",
-            )
+        # The name of the incident grid
+        self.add_argument(
+            "--incident-grid",
+            type=str,
+            required=True,
+            help="The name of the incident grid (the grid "
+            "used to generate the cloudy runs).",
+        )
 
-            # The name for the new cloudy reprocessed grid (by default this
-            # is the same as the incident grid with a '_cloudy' suffix)
-            self.add_argument(
-                "--cloudy-grid",
-                type=str,
-                required=False,
-                description="The name of the new cloudy reprocessed grid.",
-            )
+        # The name for the new cloudy reprocessed grid (by default this
+        # is the same as the incident grid with a '_cloudy' suffix)
+        self.add_argument(
+            "--cloudy-grid",
+            type=str,
+            required=False,
+            default=None,
+            help="The name of the new cloudy reprocessed grid.",
+        )
 
-            # The cloudy parameters, including any grid axes
-            self.add_argument(
-                "--cloudy-params",
-                type=str,
-                required=False,
-                default="c17.03-sps",
-                description="The path to the cloudy parameter file.",
-            )
+        # The cloudy parameters, including any grid axes
+        self.add_argument(
+            "--cloudy-params",
+            type=str,
+            required=False,
+            default="c17.03-sps",
+            help="The path to the cloudy parameter file.",
+        )
 
-            # A second cloudy parameter set which supersedes the above
-            self.add_argument(
-                "--cloudy_params_addition",
-                type=str,
-                required=False,
-                description="The path to the cloudy 'extra' parameter file.",
-            )
+        # A second cloudy parameter set which supersedes the above
+        self.add_argument(
+            "--cloudy-params-addition",
+            type=str,
+            required=False,
+            help="The path to the cloudy 'extra' parameter file.",
+        )
 
-            # Should we include the spectra in the grid?
-            self.add_argument(
-                "--include_spectra",
-                type=bool,
-                default=True,
-                required=False,
-                description="Should the spectra be included in the grid?",
-            )
+        # Should we include the spectra in the grid?
+        self.add_argument(
+            "--include-spectra",
+            type=bool,
+            default=True,
+            required=False,
+            help="Should the spectra be included in the grid?",
+        )
 
-            # Boolean flag as to whether to attempt to replace missing files
-            self.add_argument(
-                "--replace",
-                type=bool,
-                default=False,
-                required=False,
-                description="Should missing files be replaced?",
-            )
+        # Boolean flag as to whether to attempt to replace missing files
+        self.add_argument(
+            "--replace",
+            type=bool,
+            default=False,
+            required=False,
+            help="Should missing files be replaced?",
+        )
 
-            # Define the line calculation method.
-            self.add_argument(
-                "--line_calc_method",
-                type=str,
-                default="lines",
-                required=False,
-                description="The method used to calculate the line fluxes "
-                "(either 'lines' or 'linelist')",
-            )
+        # Define the line calculation method.
+        self.add_argument(
+            "--line-calc-method",
+            type=str,
+            default="lines",
+            required=False,
+            help="The method used to calculate the line fluxes "
+            "(either 'lines' or 'linelist')",
+        )
 
-            # Define the machine (for rerunning cloudy runs)
-            self.add_argument(
-                "--machine",
-                type=str,
-                default=None,
-                required=False,
-                description="The machine used to run the cloudy runs "
-                "(currently only supports apollo)",
-            )
+        # Define the machine (for rerunning cloudy runs)
+        self.add_argument(
+            "--machine",
+            type=str,
+            default=None,
+            required=False,
+            help="The machine used to run the cloudy runs "
+            "(currently only supports apollo)",
+        )
+
+        # Should we normalise by the specific ionising luminosity?
+        self.add_argument(
+            "--norm-by-Q",
+            "-Q",
+            action="store_true",
+            default=True,
+            help="Should the grid be normalised by the specific "
+            "ionising luminosity?",
+        )
 
     def _add_alpha_args(self):
         """Add arguments for alpha enhancement."""

--- a/src/synthesizer_grids/parser.py
+++ b/src/synthesizer_grids/parser.py
@@ -51,7 +51,7 @@ class Parser(argparse.ArgumentParser):
             "--verbose",
             type=bool,
             required=False,
-            default=True,
+            default=False,
             description="Are we talking?",
         )
 


### PR DESCRIPTION
As it was, the arguments for the cloudy script had to be very specific and follow a specific format. Combined with the lack of documentation for these arguments this made for a confusing experience when first trying to run `create_synthesizer_grid`. This has now been simplified right down where each argument points to the necessary files with no need for implicit relationships between the paths. 

In addition, the Cloudy parameters are now written to a `CloudyParams` group in the grid file so it is obvious what the attributes are (previously they floated at the root).

I have updated the README to reflect this.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
