### PR TITLE
Update to BC03-2016 grids: remnant mass and lowest age switch

### DIFF
--- a/src/synthesizer_grids/incident/sps/install_bc03-2016.py
+++ b/src/synthesizer_grids/incident/sps/install_bc03-2016.py
@@ -36,7 +36,7 @@ def extract_and_decompress_ised_files(directory):
 
     for root, dirs, files in os.walk(directory):
         for file in files:
-            if file.endswith(".ised.gz"):
+            if file.endswith(".ised.gz") or file.endswith(".3color.gz"):
                 gz_file_path = os.path.join(root, file)
                 new_file_path = os.path.join(input_dir, file)
                 with gzip.open(gz_file_path, "rb") as gz_file:
@@ -317,7 +317,7 @@ def make_grid(variant, imf_type, input_dir, out_filename):
     metallicities = out[1]
 
     ages = out[2]
-    ages[0] = 1e5
+    ages[0] = 1.0
 
     lam = out[3]
     nu = 3e8 / (lam * 1e-10)
@@ -353,6 +353,31 @@ def make_grid(variant, imf_type, input_dir, out_filename):
 
     # Include the specific ionising photon luminosity
     out_grid.add_specific_ionising_lum()
+
+    stellar_fraction = np.ones((len(ages), len(metallicities)))
+    remnant_fraction = np.zeros((len(ages), len(metallicities)))
+
+    for ii, file in enumerate(files):
+        file = file[:-10] + "3color"
+        req_file = f"{input_dir}/{file}"
+        data = np.genfromtxt(req_file, comments="#")
+        remnant_fraction[1:, ii] = data[:, 15]
+
+    stellar_fraction = 1.0 - remnant_fraction
+
+    # Write surviving and remnant datasets
+    out_grid.write_dataset(
+        "star_fraction",
+        stellar_fraction * dimensionless,
+        "Two-dimensional remaining stellar fraction grid, [age, Z]",
+        log_on_read=False,
+    )
+    out_grid.write_dataset(
+        "remnant_fraction",
+        remnant_fraction * dimensionless,
+        "Two-dimensional remaining remnant fraction grid, [age, Z]",
+        log_on_read=False,
+    )
 
 
 if __name__ == "__main__":

--- a/src/synthesizer_grids/incident/sps/install_bc03-2016.py
+++ b/src/synthesizer_grids/incident/sps/install_bc03-2016.py
@@ -30,8 +30,8 @@ from synthesizer_grids.parser import Parser
 
 
 def extract_and_decompress_ised_files(directory):
-    """Walk through the extracted directory and extract the ised files to the
-    top directory and delete anything else.
+    """Walk through the extracted directory and extract the ised and 3color
+    files to the top directory and delete anything else.
     """
 
     for root, dirs, files in os.walk(directory):

--- a/src/synthesizer_grids/incident/sps/install_bc03-2016.py
+++ b/src/synthesizer_grids/incident/sps/install_bc03-2016.py
@@ -354,9 +354,12 @@ def make_grid(variant, imf_type, input_dir, out_filename):
     # Include the specific ionising photon luminosity
     out_grid.add_specific_ionising_lum()
 
+    # Add surviving mass to grid
     stellar_fraction = np.ones((len(ages), len(metallicities)))
     remnant_fraction = np.zeros((len(ages), len(metallicities)))
 
+    # Remnant mass fraction is stored in the 3color file
+    # as the 16th entry
     for ii, file in enumerate(files):
         file = file[:-10] + "3color"
         req_file = f"{input_dir}/{file}"


### PR DESCRIPTION
## Issue Type
- Enhancement

I have added the remnant mass fraction for the BC03-2016 grids. I have also updated the lowest age, which is 0 in the raw files, to 1 yr to avoid future issues with logscale. Shouldn't make any difference in the grand scheme of things.

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * BC03-2016 grid now computes and outputs stellar fraction and remnant fraction datasets.
  * Enhanced auxiliary file extraction during grid installation process.

* **Updates**
  * Adjusted initial age bin configuration for improved accuracy in grid generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->